### PR TITLE
Add minimal Chrome extension for Georgia SOS name search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # XAMAN
-NAME VERIFIER (GA)
+
+Herramienta mínima para verificar la disponibilidad de nombres de compañía en el sitio del Secretario de Estado de Georgia.
+
+## Extensión de Chrome
+
+Los archivos de la extensión se encuentran en la carpeta `extension`.
+
+### Instalación
+1. Abre `chrome://extensions` en Google Chrome.
+2. Activa **Developer mode**.
+3. Selecciona **Load unpacked** y elige la carpeta `extension` de este proyecto.
+
+### Uso
+1. Haz clic en el icono de la extensión.
+2. Escribe el nombre de la compañía que deseas verificar.
+3. Presiona **Verificar** y se abrirá una nueva pestaña con la búsqueda en [ecorp.sos.ga.gov](https://ecorp.sos.ga.gov/businesssearch).

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,11 @@
+{
+  "manifest_version": 3,
+  "name": "Georgia SOS Name Checker",
+  "version": "1.0",
+  "description": "Check company name availability on Georgia's Secretary of State site.",
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "permissions": ["tabs"],
+  "host_permissions": ["https://ecorp.sos.ga.gov/*"]
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Georgia SOS Checker</title>
+</head>
+<body>
+  <input type="text" id="companyName" placeholder="Nombre de la compañía" />
+  <button id="checkBtn">Verificar</button>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,9 @@
+document.getElementById('checkBtn').addEventListener('click', () => {
+  const name = document.getElementById('companyName').value.trim();
+  if (!name) {
+    alert('Por favor ingrese un nombre.');
+    return;
+  }
+  const url = 'https://ecorp.sos.ga.gov/BusinessSearch?SearchTerm=' + encodeURIComponent(name);
+  chrome.tabs.create({ url });
+});


### PR DESCRIPTION
## Summary
- add manifest and popup for minimal Georgia Secretary of State name search extension
- document how to load and use the extension

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e735130883268cae096d925c3830