### PR TITLE
Implement automatic Instagram follower scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ Esta extensión de Chrome te ayuda a comparar las listas de *seguidos* y *seguid
 3. Haz clic en **Load unpacked** (Cargar descomprimida) y selecciona la carpeta `extension` de este proyecto.
 
 ## Uso
-1. Abre Instagram y copia la lista de usuarios que sigues y la de tus seguidores (por ejemplo desde las ventanas modales de Instagram o desde un archivo exportado).
+
+### Lectura automática desde Instagram
+1. Abre Instagram en una pestaña y navega a tu propio perfil.
+2. Haz clic en el icono de la extensión para abrir el popup.
+3. Pulsa **Obtener datos automáticamente**. La extensión abrirá tus modales de seguidores y seguidos, hará scroll hasta leerlos por completo y rellenará los campos de forma automática.
+4. Revisa los resultados generados. Si lo prefieres, puedes volver a ejecutar el proceso o complementar los datos manualmente.
+
+### Modo manual
+1. Abre Instagram y copia la lista de usuarios que sigues y la de tus seguidores (por ejemplo, desde las ventanas modales de Instagram o desde un archivo exportado).
 2. Haz clic en el icono de la extensión para abrir el popup.
 3. Pega la lista de *seguidos* en el primer recuadro y la lista de *seguidores* en el segundo.
 4. Presiona **Encontrar no seguidores** para generar la lista de cuentas que no te siguen de vuelta.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,8 +1,10 @@
 {
   "manifest_version": 3,
   "name": "Instagram Non-Follower Finder",
-  "version": "1.0",
+  "version": "1.1",
   "description": "Compara tus seguidos y seguidores de Instagram para encontrar quién no te sigue de vuelta.",
+  "permissions": ["scripting", "tabs"],
+  "host_permissions": ["https://www.instagram.com/*"],
   "action": {
     "default_popup": "popup.html",
     "default_title": "Instagram Non-Follower Finder"

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -78,6 +78,41 @@ textarea:focus {
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
+.secondary-button {
+  background: rgba(15, 23, 42, 0.6);
+  color: rgba(226, 232, 240, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.secondary-button:hover,
+.secondary-button:focus-visible {
+  border-color: rgba(249, 115, 22, 0.6);
+  background: rgba(15, 23, 42, 0.75);
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.actions button {
+  width: 100%;
+}
+
+.primary-button:disabled,
+.secondary-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
 .primary-button:hover,
 .primary-button:focus-visible {
   transform: translateY(-1px);
@@ -139,4 +174,23 @@ textarea:focus {
 .empty-state {
   color: rgba(226, 232, 240, 0.8);
   font-style: italic;
+}
+
+.status {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.status--success {
+  color: #4ade80;
+}
+
+.status--warning {
+  color: #facc15;
+}
+
+.status--error {
+  color: #f87171;
 }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -10,7 +10,7 @@
   <main class="container">
     <h1 class="title">Instagram Non-Follower Finder</h1>
     <p class="description">
-      Pega tus listas de <strong>seguidos</strong> y <strong>seguidores</strong> para descubrir quiénes no te siguen de vuelta.
+      Pega tus listas de <strong>seguidos</strong> y <strong>seguidores</strong> o deja que la extensión los obtenga desde Instagram automáticamente.
     </p>
 
     <section class="inputs">
@@ -21,7 +21,11 @@
       <textarea id="followersInput" placeholder="Un usuario por línea o separados por comas"></textarea>
     </section>
 
-    <button id="compareButton" class="primary-button">Encontrar no seguidores</button>
+    <section class="actions">
+      <button id="autoFetchButton" class="secondary-button">Obtener datos automáticamente</button>
+      <button id="compareButton" class="primary-button">Encontrar no seguidores</button>
+      <p id="statusMessage" class="status hidden" role="status" aria-live="polite"></p>
+    </section>
 
     <section id="results" class="results hidden">
       <h2>No te siguen de vuelta</h2>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,9 +1,36 @@
 const followingInput = document.getElementById('followingInput');
 const followersInput = document.getElementById('followersInput');
 const compareButton = document.getElementById('compareButton');
+const autoFetchButton = document.getElementById('autoFetchButton');
 const resultsSection = document.getElementById('results');
 const resultCount = resultsSection.querySelector('.result-count');
 const resultList = resultsSection.querySelector('.result-list');
+const statusMessage = document.getElementById('statusMessage');
+
+const STATUS_MODIFIERS = ['status--success', 'status--warning', 'status--error'];
+
+const setStatus = (message, type = 'info') => {
+  if (!statusMessage) {
+    return;
+  }
+
+  statusMessage.textContent = message;
+  statusMessage.classList.remove('hidden', ...STATUS_MODIFIERS);
+
+  if (type !== 'info') {
+    statusMessage.classList.add(`status--${type}`);
+  }
+};
+
+const clearStatus = () => {
+  if (!statusMessage) {
+    return;
+  }
+
+  statusMessage.textContent = '';
+  statusMessage.classList.add('hidden');
+  statusMessage.classList.remove(...STATUS_MODIFIERS);
+};
 
 const normalizeUsernames = (rawText) => {
   return rawText
@@ -57,4 +84,260 @@ compareButton.addEventListener('click', () => {
     item.appendChild(link);
     resultList.appendChild(item);
   });
+});
+
+autoFetchButton?.addEventListener('click', async () => {
+  clearStatus();
+
+  autoFetchButton.disabled = true;
+  compareButton.disabled = true;
+  setStatus('Iniciando lectura automática...', 'info');
+
+  try {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+
+    if (!tab || !tab.id) {
+      throw new Error('No se pudo identificar la pestaña activa.');
+    }
+
+    if (!tab.url || !tab.url.startsWith('https://www.instagram.com/')) {
+      throw new Error('Abre tu perfil de Instagram y vuelve a intentarlo.');
+    }
+
+    setStatus('Leyendo tus seguidores y seguidos en Instagram...', 'info');
+
+    const [injectionResult] = await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: async () => {
+        const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+        const waitFor = async (conditionFn, timeout = 10000, interval = 100, timeoutMessage = 'timeout') => {
+          const start = Date.now();
+          while (Date.now() - start < timeout) {
+            const value = conditionFn();
+            if (value) {
+              return value;
+            }
+            await sleep(interval);
+          }
+          throw new Error(timeoutMessage);
+        };
+
+        const parseCountText = (textContent) => {
+          if (!textContent) {
+            return 0;
+          }
+
+          const normalized = textContent.toLowerCase();
+          if (!/(k|m|b|mil)/.test(normalized)) {
+            const digits = normalized.replace(/\D/g, '');
+            return digits ? parseInt(digits, 10) : 0;
+          }
+
+          const numberMatch = normalized.match(/[\d.,]+/);
+          if (!numberMatch) {
+            return 0;
+          }
+
+          const numeric = parseFloat(numberMatch[0].replace(/,/g, '.'));
+          if (Number.isNaN(numeric)) {
+            return 0;
+          }
+
+          let multiplier = 1;
+          if (normalized.includes('mil') || normalized.includes('k')) {
+            multiplier = 1_000;
+          } else if (normalized.includes('m')) {
+            multiplier = 1_000_000;
+          } else if (normalized.includes('b')) {
+            multiplier = 1_000_000_000;
+          }
+
+          return Math.round(numeric * multiplier);
+        };
+
+        const extractUsernameFromHref = (href) => {
+          if (!href) {
+            return null;
+          }
+
+          const sanitized = href.split('?')[0].replace(/^https?:\/\/[^/]+/, '');
+          const cleanPath = sanitized.replace(/^\/+|\/+$/g, '');
+          if (!cleanPath) {
+            return null;
+          }
+
+          const [username] = cleanPath.split('/');
+          return username ? username.toLowerCase() : null;
+        };
+
+        const findScrollableParent = (element) => {
+          let current = element;
+          while (current && current !== document.body) {
+            const hasScroll = current.scrollHeight > current.clientHeight + 5;
+            if (hasScroll) {
+              return current;
+            }
+            current = current.parentElement;
+          }
+          return element;
+        };
+
+        const closeActiveDialog = async () => {
+          const dialog = document.querySelector('div[role="dialog"]');
+          if (!dialog) {
+            return;
+          }
+
+          const closeButton = dialog.querySelector(
+            'button[aria-label="Cerrar"], button[aria-label="Close"], div[role="button"][aria-label="Cerrar"], div[role="button"][aria-label="Close"]'
+          );
+
+          if (closeButton) {
+            closeButton.click();
+          } else {
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', keyCode: 27, which: 27, bubbles: true }));
+            document.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape', keyCode: 27, which: 27, bubbles: true }));
+          }
+
+          await sleep(400);
+          try {
+            await waitFor(
+              () => !document.querySelector('div[role="dialog"]'),
+              3_000,
+              100,
+              'No se pudo cerrar una ventana emergente de Instagram.'
+            );
+          } catch (error) {
+            console.warn(error);
+          }
+        };
+
+        const collectList = async (type) => {
+          const label = type === 'followers' ? 'seguidores' : 'seguidos';
+          await closeActiveDialog();
+
+          const selectors = [`a[href$="/${type}/"]`, `a[href*="/${type}/?"]`, `a[href$="/${type}"]`];
+          let trigger = null;
+
+          for (const selector of selectors) {
+            const element = document.querySelector(selector);
+            if (element) {
+              trigger = element;
+              break;
+            }
+          }
+
+          if (!trigger) {
+            throw new Error(`No se encontró el acceso directo a tus ${label} en el perfil actual.`);
+          }
+
+          const total = parseCountText(trigger.textContent);
+          trigger.click();
+
+          const dialog = await waitFor(
+            () => document.querySelector('div[role="dialog"]'),
+            10_000,
+            100,
+            'No se pudo abrir la ventana con la lista solicitada.'
+          );
+          const list = await waitFor(
+            () => dialog.querySelector('ul'),
+            10_000,
+            100,
+            'No se pudo cargar la lista de usuarios desde Instagram.'
+          );
+          const scrollContainer = findScrollableParent(list);
+
+          const collectUsernames = () => {
+            const items = Array.from(dialog.querySelectorAll('ul li'));
+            const seen = new Set();
+            const usernames = [];
+
+            for (const item of items) {
+              const anchor = item.querySelector('a[href^="/"][role="link"]');
+              const username = extractUsernameFromHref(anchor?.getAttribute('href'));
+              if (!username || seen.has(username)) {
+                continue;
+              }
+              seen.add(username);
+              usernames.push(username);
+            }
+
+            return usernames;
+          };
+
+          let stableIterations = 0;
+          let usernames = collectUsernames();
+
+          while ((!total || usernames.length < total) && stableIterations < 10) {
+            scrollContainer.scrollTop = scrollContainer.scrollHeight;
+            await sleep(650);
+            const updated = collectUsernames();
+            if (updated.length === usernames.length) {
+              stableIterations += 1;
+            } else {
+              stableIterations = 0;
+            }
+            usernames = updated;
+          }
+
+          await closeActiveDialog();
+          await sleep(250);
+
+          return {
+            total,
+            usernames,
+            reachedTotal: !total || usernames.length >= total,
+          };
+        };
+
+        const followers = await collectList('followers');
+        const following = await collectList('following');
+
+        return { followers, following };
+      },
+    });
+
+    if (!injectionResult) {
+      throw new Error('No se pudo leer la respuesta de la pestaña.');
+    }
+
+    if (injectionResult.error) {
+      throw new Error(injectionResult.error.message || 'Se produjo un error durante la lectura automática.');
+    }
+
+    const data = injectionResult.result;
+
+    if (!data || !data.followers || !data.following) {
+      throw new Error('Instagram no devolvió información válida.');
+    }
+
+    const followersList = data.followers.usernames || [];
+    const followingList = data.following.usernames || [];
+
+    followersInput.value = followersList.join('\n');
+    followingInput.value = followingList.join('\n');
+
+    const reachedAll = (data.followers.reachedTotal ?? true) && (data.following.reachedTotal ?? true);
+
+    compareButton.disabled = false;
+    compareButton.click();
+
+    const summary = `Seguidos leídos: ${followingList.length}${
+      data.following.total ? ` / ${data.following.total}` : ''
+    } · Seguidores leídos: ${followersList.length}${data.followers.total ? ` / ${data.followers.total}` : ''}`;
+
+    if (reachedAll) {
+      setStatus(`Lectura completada. ${summary}`, 'success');
+    } else {
+      setStatus(`Lectura completada con advertencias. ${summary}`, 'warning');
+    }
+  } catch (error) {
+    console.error(error);
+    setStatus(error.message || 'Ocurrió un error inesperado durante la lectura automática.', 'error');
+  } finally {
+    autoFetchButton.disabled = false;
+    compareButton.disabled = false;
+  }
 });


### PR DESCRIPTION
## Summary
- add a Chrome scripting workflow that opens the Instagram followers and following modals, scrolls through them, and collects usernames automatically
- update the popup interface with an auto-fetch button, status messaging, and automatic comparison triggering after data collection
- document the automatic workflow and update the manifest with the required permissions and version bump

## Testing
- not run (manual testing recommended)


------
https://chatgpt.com/codex/tasks/task_e_68cc767afb448326abccd30062375cce